### PR TITLE
Fix token rotation, session management, and blog cache invalidation

### DIFF
--- a/backend/src/routes/auth.route.ts
+++ b/backend/src/routes/auth.route.ts
@@ -63,13 +63,17 @@ authRouter.get('/google', async (c) => {
 })
 
 authRouter.get('/refresh', async (c) => {
-   const config = getConfig(c.env)
-   if (!c.env) { return c.json({ message: "Server configuration error" }, 500) }
-   const authService = createAuthService(config)
-   const authController = createAuthController(authService)
-   const res = await authController.generateRefreshToken(c)
-   return c.json({ message: res })
-
+   try {
+      const config = getConfig(c.env)
+      if (!c.env) { return c.json({ message: "Server configuration error" }, 500) }
+      const authService = createAuthService(config)
+      const authController = createAuthController(authService)
+      const res = await authController.generateRefreshToken(c)
+      // If we get here, refresh was successful
+      return c.json({ message: "Token refreshed successfully", ...res })
+   } catch (error) {
+      return handleError(c, error)
+   }
 })
 
 

--- a/frontend/src/components/LogoutButton.tsx
+++ b/frontend/src/components/LogoutButton.tsx
@@ -1,5 +1,4 @@
-import axios from "axios"
-import { BACKEND_URL } from "../config"
+import api from "../lib/axios"
 import { useNavigate } from "react-router-dom"
 import { toast } from "sonner"
 import { Button } from "./ui/button"
@@ -9,18 +8,23 @@ import { useQueryClient } from "@tanstack/react-query"
 
 export const LogoutButton = () => {
   const navigate = useNavigate()
-  const { logout } = useAuth()
+  const { clearSession } = useAuth()
   const queryClient = useQueryClient()
   
   async function handleLogout() {
     try {
-      await axios.post(`${BACKEND_URL}/api/v1/auth/logout`, {}, { withCredentials: true })
-      logout()
+      await api.post('/api/v1/auth/logout')
+      clearSession()
       queryClient.clear()
       toast.success("Logged out successfully")
       navigate('/signin')
     } catch {
-      toast.error("Unable to logout, try again")
+      // Even if backend fails (e.g., expired token), we should still logout locally
+      // This is the key fix for when users can't logout due to expired tokens
+      clearSession()
+      queryClient.clear()
+      toast.success("Logged out successfully")
+      navigate('/signin')
     }
   }
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react'
-import axios from 'axios'
-import { BACKEND_URL } from '../config'
+import api from '../lib/axios'
 
 interface User {
   id: string
@@ -17,6 +16,7 @@ interface AuthContextType {
   setUserName: (name: string) => void
   logout: () => void
   checkAuth: () => Promise<void>
+  clearSession: () => void
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -31,37 +31,87 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem('userName', name)
   }, [])
 
-  // Check authentication status on mount by calling backend
+  /**
+   * Clear session state completely - used when tokens are invalid/expired
+   * This ensures the user is properly logged out even if backend call fails
+   */
+  const clearSession = useCallback(() => {
+    setUser(null)
+    setUserNameState('Anonymous')
+    localStorage.removeItem('userName')
+    // Also try to clear any isAuthenticated indicator
+    localStorage.removeItem('isAuthenticated')
+  }, [])
+
+  /**
+   * Logout function that calls backend and clears local state
+   * If backend call fails (e.g., due to expired tokens), still clear local state
+   */
+  const logout = useCallback(async () => {
+    try {
+      await api.post('/api/v1/auth/logout')
+    } catch {
+      // Even if backend logout fails, we should still clear local state
+      // This handles the case where tokens are already expired
+      console.warn('Backend logout failed, clearing local session anyway')
+    }
+    // Always clear session regardless of backend response
+    clearSession()
+  }, [clearSession])
+
+  /**
+   * Check authentication status by calling backend
+   * If the call fails with 401, the axios interceptor will try to refresh
+   * If refresh also fails, session will be cleared via the sessionExpired event
+   */
   const checkAuth = useCallback(async () => {
     try {
       setIsLoading(true)
-      const response = await axios.get(`${BACKEND_URL}/api/v1/user/profile_info`, {
-        withCredentials: true
-      })
+      const response = await api.get('/api/v1/user/profile_info')
       
       // API returns { userProfile: { id, name, email, ... } }
       const userProfile = response.data?.userProfile
       if (userProfile && userProfile.name) {
         setUserName(userProfile.name)
         setUser(userProfile)
+        localStorage.setItem('isAuthenticated', 'true')
+      } else {
+        clearSession()
       }
     } catch {
-      // Not authenticated, clear state
-      setUser(null)
+      // Not authenticated or session expired, clear state
+      clearSession()
     } finally {
       setIsLoading(false)
     }
-  }, [setUserName])
+  }, [setUserName, clearSession])
 
+  // Listen for session expired events from axios interceptor
+  useEffect(() => {
+    const handleSessionExpired = () => {
+      clearSession()
+    }
+
+    window.addEventListener('auth:sessionExpired', handleSessionExpired)
+    return () => {
+      window.removeEventListener('auth:sessionExpired', handleSessionExpired)
+    }
+  }, [clearSession])
+
+  // Check authentication on mount
   useEffect(() => {
     checkAuth()
   }, [checkAuth])
 
+  // Sync with localStorage if it changes in other tabs
   useEffect(() => {
-    // Sync with localStorage if it changes in other tabs
     const handleStorageChange = (e: StorageEvent) => {
       if (e.key === 'userName' && e.newValue) {
         setUserNameState(e.newValue)
+      }
+      if (e.key === 'isAuthenticated' && e.newValue === null) {
+        // User logged out in another tab
+        clearSession()
       }
     }
 
@@ -70,23 +120,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => {
       window.removeEventListener('storage', handleStorageChange)
     }
-  }, [])
+  }, [clearSession])
 
-  const logout = useCallback(() => {
-    setUser(null)
-    setUserNameState('Anonymous')
-    localStorage.removeItem('userName')
-  }, [])
-
+  // isAuthenticated is now based on actual user object, not localStorage
   const value: AuthContextType = {
     user,
-    isAuthenticated: !!user || (!!userName && userName !== 'Anonymous'),
+    isAuthenticated: !!user,
     isLoading,
-    userName,
+    userName: user?.name || userName,
     setUser,
     setUserName,
     logout,
-    checkAuth
+    checkAuth,
+    clearSession
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -1,0 +1,86 @@
+/**
+ * Axios instance with interceptors for handling token refresh
+ * This provides automatic token rotation when access tokens expire
+ */
+
+import axios, { AxiosError } from 'axios'
+import type { InternalAxiosRequestConfig } from 'axios'
+import { BACKEND_URL } from '../config'
+
+// Flag to prevent multiple refresh requests
+let isRefreshing = false
+
+// Queue to hold requests while refreshing
+let failedQueue: Array<{
+    resolve: (value: unknown) => void
+    reject: (error: unknown) => void
+}> = []
+
+const processQueue = (error: Error | null) => {
+    failedQueue.forEach((prom) => {
+        if (error) {
+            prom.reject(error)
+        } else {
+            prom.resolve(undefined)
+        }
+    })
+    failedQueue = []
+}
+
+// Create axios instance
+const api = axios.create({
+    baseURL: BACKEND_URL,
+    withCredentials: true,
+    headers: {
+        'Content-Type': 'application/json',
+    },
+})
+
+// Response interceptor to handle token refresh
+api.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+        const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean }
+
+        // Check if error is 401 and we haven't already retried
+        if (error.response?.status === 401 && !originalRequest._retry) {
+            // Don't retry for refresh endpoint itself to avoid infinite loop
+            if (originalRequest.url?.includes('/auth/refresh')) {
+                // Refresh token is also invalid, redirect to login
+                window.dispatchEvent(new CustomEvent('auth:sessionExpired'))
+                return Promise.reject(error)
+            }
+
+            if (isRefreshing) {
+                // If we're already refreshing, queue this request
+                return new Promise((resolve, reject) => {
+                    failedQueue.push({ resolve, reject })
+                })
+                    .then(() => api(originalRequest))
+                    .catch((err) => Promise.reject(err))
+            }
+
+            originalRequest._retry = true
+            isRefreshing = true
+
+            try {
+                // Attempt to refresh the token
+                await api.get('/api/v1/auth/refresh')
+                processQueue(null)
+                // Retry the original request
+                return api(originalRequest)
+            } catch (refreshError) {
+                processQueue(refreshError as Error)
+                // Refresh failed, dispatch session expired event
+                window.dispatchEvent(new CustomEvent('auth:sessionExpired'))
+                return Promise.reject(refreshError)
+            } finally {
+                isRefreshing = false
+            }
+        }
+
+        return Promise.reject(error)
+    }
+)
+
+export default api


### PR DESCRIPTION
## Summary
This PR fixes critical authentication and UX issues where users returning after a long period were stuck (couldn't logout or access protected routes), and newly created blogs weren't appearing immediately.

## Problems Fixed

### 1. Token Rotation Issue 🔐
**Before:** Users with expired access tokens but valid refresh tokens were stuck - couldn't access the app or logout.

**After:** Automatic token refresh via Axios interceptor. If refresh fails, users are properly redirected to signin.

### 2. Logout Not Working 🚪
**Before:** Logout failed silently when tokens were expired, leaving users stuck.

**After:** Logout always clears local session and redirects to signin, even if backend call fails.

### 3. New Blogs Not Showing Immediately 📝
**Before:** After publishing a blog, it wouldn't appear on the blogs list until manual refresh.

**After:** React Query cache is properly invalidated after create/update operations.

## Changes

### Backend
- [auth.service.ts](cci:7://file:///home/bot/repos/Cohort/Week13/medium/backend/src/services/auth.service.ts:0:0-0:0): Strip JWT metadata (exp, iat) from refresh tokens before regenerating
- [auth.route.ts](cci:7://file:///home/bot/repos/Cohort/Week13/medium/backend/src/routes/auth.route.ts:0:0-0:0): Added proper error handling for `/refresh` endpoint

### Frontend
- **New:** [lib/axios.ts](cci:7://file:///home/bot/repos/Cohort/Week13/medium/frontend/src/lib/axios.ts:0:0-0:0) - Centralized Axios instance with token refresh interceptor
- [AuthContext.tsx](cci:7://file:///home/bot/repos/Cohort/Week13/medium/frontend/src/context/AuthContext.tsx:0:0-0:0) - Session management with `clearSession` + event listener for expired tokens
- [LogoutButton.tsx](cci:7://file:///home/bot/repos/Cohort/Week13/medium/frontend/src/components/LogoutButton.tsx:0:0-0:0) - Graceful logout even with expired tokens
- [queries.ts](cci:7://file:///home/bot/repos/Cohort/Week13/medium/frontend/src/hooks/queries.ts:0:0-0:0) - Added [useCreateBlog](cci:1://file:///home/bot/repos/Cohort/Week13/medium/frontend/src/hooks/queries.ts:376:0-402:1) and [useUpdateBlog](cci:1://file:///home/bot/repos/Cohort/Week13/medium/frontend/src/hooks/queries.ts:404:0-426:1) hooks with cache invalidation
- [Publish.tsx](cci:7://file:///home/bot/repos/Cohort/Week13/medium/frontend/src/pages/Publish.tsx:0:0-0:0) & [EditBlog.tsx](cci:7://file:///home/bot/repos/Cohort/Week13/medium/frontend/src/pages/EditBlog.tsx:0:0-0:0) - Refactored to use mutation hooks

## Testing
- [x] Frontend build passes
- [x] Backend typecheck passes
- [ ] Manual testing: Login → Wait for token expiry → Access protected route → Should auto-refresh
- [ ] Manual testing: Create blog → Should appear immediately on blogs list